### PR TITLE
Fill Project Information From Template

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,3 @@ updates:
     commit-message:
       prefix: chore
     labels: [chore]
-
-  # You can add another configuration here to automatically update the other dependencies of your project.
-  # Learn more: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,3 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.5
-
-      # Add steps here to build and test your project.
-      # Learn more: https://docs.github.com/en/actions/automating-builds-and-tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 .*
 !.git*
-
-# Add additional glob patterns here to specify more files or directories to be ignored by Git.
-# Learn more: https://git-scm.com/docs/gitignore

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-<!-- Clear the content of this file and replace it with the description of your project. -->
-<!-- Learn more: https://www.makeareadme.com -->
+# Rust Starter
 
-# Project Starter
+A minimalistic [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) to kickstart your [Rust](https://www.rust-lang.org/) project
 
-The Project Starter is a [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) that provides a minimalistic boilerplate to kickstart any type of project on [GitHub](https://github.com/). Use this template to initialize your project with preconfigured settings recommended for various GitHub projects.
-
-## Features
+## Key Features
 
 - Preconfigured [GitHub Actions](https://github.com/features/actions) to automate your project workflow.
 - Preconfigured [Dependabot](https://docs.github.com/en/code-security/dependabot) to keep your project dependencies up to date.
 
 ## Usage
 
-Refer to [this wiki](https://github.com/threeal/project-starter/wiki) for information on how to use this template.
+Refer to [this wiki](https://github.com/threeal/rust-starter/wiki) for information on how to use this template.


### PR DESCRIPTION
This pull request resolves #2 by filling in the project information from the [Project Starter](https://github.com/threeal/project-starter) template as follows:
- Fills in the content of the `README.md` file.
- Removes all guidance comments.