### PR TITLE
Add Coverage Check in Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,13 +12,10 @@ jobs:
       - name: Check Out Project
         uses: actions/checkout@v4.1.5
 
-      - name: Test Package
-        run: cargo test
-
       - name: Install tarpaulin
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-tarpaulin
 
-      - name: Check Test Coverage
+      - name: Test Package
         run: cargo tarpaulin --fail-under 45

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,3 +14,11 @@ jobs:
 
       - name: Test Package
         run: cargo test
+
+      - name: Install tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
+
+      - name: Check Test Coverage
+        run: cargo tarpaulin --fail-under 45


### PR DESCRIPTION
This pull request resolves #10 by utilizing [tarpaulin](https://crates.io/crates/cargo-tarpaulin) in the Test workflow for testing the package and checking the test coverage.