### PR TITLE
Add Tarpaulin Config File

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,4 +18,4 @@ jobs:
           tool: cargo-tarpaulin
 
       - name: Test Package
-        run: cargo tarpaulin --fail-under 45
+        run: cargo tarpaulin

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,0 +1,3 @@
+[all-features-coverage]
+all-features = true
+fail-under = 45


### PR DESCRIPTION
This pull request resolves #14 by adding a `tarpaulin.toml` configuration file for specifying the minimum test coverage percentage.