### PR TITLE
Remove Upload Artifact Steps in CI Workflows

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -14,8 +14,3 @@ jobs:
 
       - name: Package Crate
         run: cargo package
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          path: target/package/*.crate


### PR DESCRIPTION
This pull request resolves #78 by removing the upload artifact steps from the `package` workflow.