### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build Crate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check Out Project
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Check Crate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check Out Project
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Package Crate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check Out Project
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Test Crate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check Out Project
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
This pull request resolves #80 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.