### PR TITLE
Integrate Lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  piped: true
+  jobs:
+    - name: check types
+      run: cargo check
+
+    - name: fix formatting
+      run: cargo fmt
+
+    - name: check diff
+      run: git diff --exit-code Cargo.lock {staged_files}


### PR DESCRIPTION
This pull request resolves #84 by integrating [Lefthook](https://lefthook.dev/) into this template, allowing pre-commit hooks to be installed and executed on staged files.