### PR TITLE
Rename Example Project to bonacci

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bonacci"
+version = "0.0.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,13 +96,6 @@ name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
-
-[[package]]
-name = "rust-starter"
-version = "0.1.0"
-dependencies = [
- "clap",
-]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "rust-starter"
-version = "0.1.0"
-authors = ["Alfi Maulana <alfi.maulana.f@gmail.com>"]
+name = "bonacci"
+version = "0.0.0"
+authors = ["Leonardo Bonacci <leonardo@bonacci.com>"]
 edition = "2021"
-description = "A starter Rust crate for generating Fibonacci sequences"
-repository = "https://github.com/threeal/rust-starter"
+description = "An example Rust project for generating a Fibonacci sequence"
+repository = "https://github.com/leonardo/bonacci"
 license = "Unlicense"
-keywords = ["rust", "starter", "fibonacci"]
+keywords = ["example", "fibonacci"]
 categories = ["algorithms", "mathematics"]
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let matches = clap::Command::new("generate_sequence")
+    let matches = clap::Command::new("bonacci")
         .version("0.1.0")
         .about("Generate a Fibonacci sequence up to the given number of terms")
         .arg(
@@ -10,7 +10,7 @@ fn main() {
         .get_matches();
 
     let n = matches.get_one::<usize>("n").unwrap_or(&0);
-    let output = rust_starter::fibonacci_sequence(*n)
+    let output = bonacci::fibonacci_sequence(*n)
         .iter()
         .map(|x| x.to_string())
         .collect::<Vec<_>>()


### PR DESCRIPTION
This pull request resolves #88 mainly by renaming the example project to `bonacci`. This change also modifies the project metadata in the `Cargo.toml` file to use an example metadata.